### PR TITLE
chore: add DevOps build pipeline for S360 security vulnerability scanning

### DIFF
--- a/.azurepipelines/build.yml
+++ b/.azurepipelines/build.yml
@@ -22,6 +22,17 @@ extends:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-2022
+        os: windows
+      credscan:
+        enabled: true
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
     stages:
       - stage: Build
         jobs:

--- a/.azurepipelines/build.yml
+++ b/.azurepipelines/build.yml
@@ -2,8 +2,8 @@ trigger: none
 pr: none
 
 schedules:
-  - cron: '0 0 * * 1,3'
-    displayName: Monday and Wednesday builds
+  - cron: '0 0 * * *'
+    displayName: Daily builds
     branches:
       include:
         - main

--- a/.azurepipelines/build.yml
+++ b/.azurepipelines/build.yml
@@ -1,0 +1,49 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: '0 0 * * 1,3'
+    displayName: Monday and Wednesday builds
+    branches:
+      include:
+        - main
+    always: true
+
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      os: linux
+    stages:
+      - stage: Build
+        jobs:
+          - job: Build
+            displayName: Build TypeScript Beta SDK
+            steps:
+              - checkout: self
+                submodules: recursive
+
+              - task: NodeTool@0
+                displayName: Set up Node.js
+                inputs:
+                  versionSpec: '20.x'
+
+              - script: npm ci
+                displayName: Install dependencies
+                workingDirectory: $(Build.SourcesDirectory)
+
+              - script: npm run build --workspaces
+                displayName: Build SDK
+                workingDirectory: $(Build.SourcesDirectory)
+
+              - script: npm test
+                displayName: Run unit tests
+                workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
## Summary
Adds a DevOps build pipeline to build this SDK so that we may surface any S360 security vulnerabilities early and on a consistent basis.

## Changes
- Added a build pipeline configuration to enable regular SDK builds
- Enables early detection of S360 security vulnerabilities through consistent automated builds

## Motivation
Proactive security scanning helps catch vulnerabilities before they reach production, aligning with S360 compliance requirements.