### PR TITLE
fix: update @microsoft/kiota-http-fetchlibrary to resolve security vulnerability GHSA-396q-4vc8-28x9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,79 +27,79 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
-      "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.9.1",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
-      "integrity": "sha512-bM3308LRyg5g7r3Twprtqww0R/r7+GyVxj4BafcmVPo4WQoGt5JXuaqxHEFjw2o3rvFZcUPiqJMg6WuvEEeVUA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
-      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
-      "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -125,47 +125,47 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
-      "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "license": "MIT",
       "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.8.0.tgz",
-      "integrity": "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1"
+        "@azure/msal-common": "16.6.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.1.tgz",
-      "integrity": "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
-      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -189,10 +189,95 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.100.tgz",
-      "integrity": "sha512-3s2WYKQ6WLB/0pyDmmv9bigH/3LZ0Mm4ldHskNLBj0U8DYjFzfG729snnEij+hZN0l2XHr37pGBr1MZK8vM7zQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.102.tgz",
+      "integrity": "sha512-WL+S7X+W6zpDO6vFk+FClb5hoUJMV1ZcMHo1H52r2Q49xTuYx9esJqmwh/0EXsftmxKwOOIOoPfO7+Tp5QAddw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -202,79 +287,79 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.100.tgz",
-      "integrity": "sha512-RT6LtekPVaFYQ5JHOiMDrYEdsx6RyiRtoGz929m3iy+jS6W2dELWTO4mrtAG3Q+8Tczk1uUwP21tYy/Wyf07lw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.102.tgz",
+      "integrity": "sha512-S+TENSTiMNI0KfXZeuuN0bQEpSOYPYviz/KiiiwByx9M96aoF/Oxagj8PoCVebbJRxrVkZrRsVyRuKt0ikfyDw==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-bundle": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.100.tgz",
-      "integrity": "sha512-ejYzO9Fku/d5IyYYegdQbMQy9cJd8O9HT8TIUA3Ty/39bzNrGG5b6MltKwqr134jTbfMjraaRmh9wD8p246lhA==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.102.tgz",
+      "integrity": "sha512-9Y8lTN6Az9Os+TbSyMxkOOMVObtslHrz5C2ohYmZ0dvbINpJskPu2K3StT6PgF0WTCVpyoxlCCYJUSoXdG4/HA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.100",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.100"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.102"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.100.tgz",
-      "integrity": "sha512-uS2rhKKjbYiT8JWG8GGVOALB+s4HdDc9hg5tTZMVf3qY5b/us1OKLQ6WgW6USq/kZAuKKWkIq/BQgPCWbHtFTQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.102.tgz",
+      "integrity": "sha512-oXfrPOWkIR2/Gs700n00EY3VDc+Qgz6y7ZiA/f8FHJsnwSjZ017xcWFw2PLzJItczVsad0pq/N5DYnoF6Co11Q==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.100.tgz",
-      "integrity": "sha512-SR/yWBtvKYhN2ARR4wVMFb91XgN32DBmLLQmtemdKgL1YWBxVCNAUP/qHbZhrTX7q4kh7jl/S9yrr1S8ySS7AA==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.102.tgz",
+      "integrity": "sha512-1w70XAA/F4RgbyNbRAaZCjLAOiKQjdiQDYlNZC9x8g7xgd7tNqYqowt/auQS1A9SZOrT626q6+Gr2xKKyW3wOg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.100.tgz",
-      "integrity": "sha512-4qatf5j0Aeaakdw24jMuIX7W6mf/W2rU9UyAjkIrSjaB7W5n8gsUvhoTcRpPTAFN7pvzQkCbO7Z0paRfdYzhIw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.102.tgz",
+      "integrity": "sha512-YpIt5pXNX13ND736oJFf0wBYPAafCv+CAE17Fa1HcS1drCdXx8ELPQ5GxGDbQG7J5LIMDgUtBOUmf5R/FrMQ6A==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.100.tgz",
-      "integrity": "sha512-zwWoLZH6+KsAl05Ijd8HpbU+mct5wb0//ZCGdCkQ/UqsAaoe2xYSoKicxQbVGv9VvSTq0as7iVLwqDeqEI9rDw==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.102.tgz",
+      "integrity": "sha512-tjwt0m+8+OqZizZU6gBARTcA8suPYS0onD9IUbhKsvRrAJpBIyp07hnyOTXBgE+gurGGbeT3TTl9AUK2ic6DiA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.100.tgz",
-      "integrity": "sha512-x2Epz0StHLBkVJKeEmwrXSh6SJuxZ72VVBNO53uHUNZ/Y7X8tZuSQR7X74EO69mEi4zAF21X2jbkF9/dhlARog==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.102.tgz",
+      "integrity": "sha512-ZCihyrXKYGfTz/frqNQvwKsD+EgjhjfclB5/XDrSGNXduisL/f1MbyvjsgmrZnLmtCwX8/v+Mc3vlz716KWYbg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.100",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
@@ -739,9 +824,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -759,19 +844,20 @@
       }
     },
     "node_modules/@std-uritemplate/std-uritemplate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.3.tgz",
-      "integrity": "sha512-oN5BHB81TMdasLZLkcdmVDFajo3CxrdeYWFKbeVw1MVZcd4jWZX6cbxm0Iq91wt/o2zsJjmefUaYrLInvZ3/DQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.10.tgz",
+      "integrity": "sha512-EGxlaZDK+CcvMYzxLWKgQlhNiyGIoznEi/CVnzM1DCiQQh/EwSH0ThvseXJ4g6btu1hvlUZ70SrZD6ahsglXcw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -789,45 +875,59 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -840,29 +940,38 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -932,22 +1041,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -992,85 +1085,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1107,9 +1121,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1137,9 +1151,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -1153,9 +1167,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1203,9 +1217,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1287,18 +1301,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-      "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.0",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1427,9 +1441,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -1448,11 +1462,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1579,9 +1610,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1593,6 +1624,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -1603,32 +1635,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1662,10 +1682,28 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1683,22 +1721,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/mocha/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1711,6 +1733,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -1745,15 +1768,15 @@
       "license": "MIT"
     },
     "node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1822,9 +1845,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1832,7 +1855,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1900,9 +1923,9 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1932,9 +1955,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1990,21 +2013,18 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/string-width-cjs": {
@@ -2023,24 +2043,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -2051,22 +2054,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi-cjs": {
@@ -2079,16 +2066,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2155,15 +2132,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2181,25 +2149,25 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
-      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -2224,65 +2192,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {
@@ -2340,51 +2262,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2400,7 +2277,7 @@
     },
     "packages/msgraph-beta-sdk": {
       "name": "@microsoft/msgraph-beta-sdk",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.100",
@@ -2413,7 +2290,7 @@
     },
     "packages/msgraph-beta-sdk-accessReviewDecisions": {
       "name": "@microsoft/msgraph-beta-sdk-accessreviewdecisions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2425,7 +2302,7 @@
     },
     "packages/msgraph-beta-sdk-accessReviews": {
       "name": "@microsoft/msgraph-beta-sdk-accessreviews",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2437,7 +2314,7 @@
     },
     "packages/msgraph-beta-sdk-activitystatistics": {
       "name": "@microsoft/msgraph-beta-sdk-activitystatistics",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2449,7 +2326,7 @@
     },
     "packages/msgraph-beta-sdk-admin": {
       "name": "@microsoft/msgraph-beta-sdk-admin",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2461,7 +2338,7 @@
     },
     "packages/msgraph-beta-sdk-administrativeUnits": {
       "name": "@microsoft/msgraph-beta-sdk-administrativeunits",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2473,7 +2350,7 @@
     },
     "packages/msgraph-beta-sdk-agreementAcceptances": {
       "name": "@microsoft/msgraph-beta-sdk-agreementacceptances",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2485,7 +2362,7 @@
     },
     "packages/msgraph-beta-sdk-agreements": {
       "name": "@microsoft/msgraph-beta-sdk-agreements",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2497,7 +2374,7 @@
     },
     "packages/msgraph-beta-sdk-allowedDataLocations": {
       "name": "@microsoft/msgraph-beta-sdk-alloweddatalocations",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2509,7 +2386,7 @@
     },
     "packages/msgraph-beta-sdk-app": {
       "name": "@microsoft/msgraph-beta-sdk-app",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2521,7 +2398,7 @@
     },
     "packages/msgraph-beta-sdk-appCatalogs": {
       "name": "@microsoft/msgraph-beta-sdk-appcatalogs",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2533,7 +2410,7 @@
     },
     "packages/msgraph-beta-sdk-applications": {
       "name": "@microsoft/msgraph-beta-sdk-applications",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2545,7 +2422,7 @@
     },
     "packages/msgraph-beta-sdk-applicationTemplates": {
       "name": "@microsoft/msgraph-beta-sdk-applicationtemplates",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2557,7 +2434,7 @@
     },
     "packages/msgraph-beta-sdk-approvalWorkflowProviders": {
       "name": "@microsoft/msgraph-beta-sdk-approvalworkflowproviders",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2569,7 +2446,7 @@
     },
     "packages/msgraph-beta-sdk-auditLogs": {
       "name": "@microsoft/msgraph-beta-sdk-auditlogs",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2581,7 +2458,7 @@
     },
     "packages/msgraph-beta-sdk-authenticationMethodConfigurations": {
       "name": "@microsoft/msgraph-beta-sdk-authenticationmethodconfigurations",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2593,7 +2470,7 @@
     },
     "packages/msgraph-beta-sdk-authenticationMethodsPolicy": {
       "name": "@microsoft/msgraph-beta-sdk-authenticationmethodspolicy",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2605,7 +2482,7 @@
     },
     "packages/msgraph-beta-sdk-bookingBusinesses": {
       "name": "@microsoft/msgraph-beta-sdk-bookingbusinesses",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2617,7 +2494,7 @@
     },
     "packages/msgraph-beta-sdk-bookingCurrencies": {
       "name": "@microsoft/msgraph-beta-sdk-bookingcurrencies",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2629,7 +2506,7 @@
     },
     "packages/msgraph-beta-sdk-businessFlowTemplates": {
       "name": "@microsoft/msgraph-beta-sdk-businessflowtemplates",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2641,7 +2518,7 @@
     },
     "packages/msgraph-beta-sdk-certificateBasedAuthConfiguration": {
       "name": "@microsoft/msgraph-beta-sdk-certificatebasedauthconfiguration",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2653,7 +2530,7 @@
     },
     "packages/msgraph-beta-sdk-chats": {
       "name": "@microsoft/msgraph-beta-sdk-chats",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2665,7 +2542,7 @@
     },
     "packages/msgraph-beta-sdk-commands": {
       "name": "@microsoft/msgraph-beta-sdk-commands",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2677,7 +2554,7 @@
     },
     "packages/msgraph-beta-sdk-communications": {
       "name": "@microsoft/msgraph-beta-sdk-communications",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2689,7 +2566,7 @@
     },
     "packages/msgraph-beta-sdk-compliance": {
       "name": "@microsoft/msgraph-beta-sdk-compliance",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2701,7 +2578,7 @@
     },
     "packages/msgraph-beta-sdk-connections": {
       "name": "@microsoft/msgraph-beta-sdk-connections",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2713,7 +2590,7 @@
     },
     "packages/msgraph-beta-sdk-contacts": {
       "name": "@microsoft/msgraph-beta-sdk-contacts",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2725,7 +2602,7 @@
     },
     "packages/msgraph-beta-sdk-contracts": {
       "name": "@microsoft/msgraph-beta-sdk-contracts",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2737,7 +2614,7 @@
     },
     "packages/msgraph-beta-sdk-dataClassification": {
       "name": "@microsoft/msgraph-beta-sdk-dataclassification",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2749,7 +2626,7 @@
     },
     "packages/msgraph-beta-sdk-dataPolicyOperations": {
       "name": "@microsoft/msgraph-beta-sdk-datapolicyoperations",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2761,7 +2638,7 @@
     },
     "packages/msgraph-beta-sdk-deviceAppManagement": {
       "name": "@microsoft/msgraph-beta-sdk-deviceappmanagement",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2773,7 +2650,7 @@
     },
     "packages/msgraph-beta-sdk-deviceManagement": {
       "name": "@microsoft/msgraph-beta-sdk-devicemanagement",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2785,7 +2662,7 @@
     },
     "packages/msgraph-beta-sdk-devices": {
       "name": "@microsoft/msgraph-beta-sdk-devices",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2797,7 +2674,7 @@
     },
     "packages/msgraph-beta-sdk-directory": {
       "name": "@microsoft/msgraph-beta-sdk-directory",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2809,7 +2686,7 @@
     },
     "packages/msgraph-beta-sdk-directoryObjects": {
       "name": "@microsoft/msgraph-beta-sdk-directoryobjects",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2821,7 +2698,7 @@
     },
     "packages/msgraph-beta-sdk-directoryRoles": {
       "name": "@microsoft/msgraph-beta-sdk-directoryroles",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2833,7 +2710,7 @@
     },
     "packages/msgraph-beta-sdk-directoryRoleTemplates": {
       "name": "@microsoft/msgraph-beta-sdk-directoryroletemplates",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2845,7 +2722,7 @@
     },
     "packages/msgraph-beta-sdk-directorySettingTemplates": {
       "name": "@microsoft/msgraph-beta-sdk-directorysettingtemplates",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2857,7 +2734,7 @@
     },
     "packages/msgraph-beta-sdk-domainDnsRecords": {
       "name": "@microsoft/msgraph-beta-sdk-domaindnsrecords",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2869,7 +2746,7 @@
     },
     "packages/msgraph-beta-sdk-domains": {
       "name": "@microsoft/msgraph-beta-sdk-domains",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2881,7 +2758,7 @@
     },
     "packages/msgraph-beta-sdk-drives": {
       "name": "@microsoft/msgraph-beta-sdk-drives",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2893,7 +2770,7 @@
     },
     "packages/msgraph-beta-sdk-education": {
       "name": "@microsoft/msgraph-beta-sdk-education",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2905,7 +2782,7 @@
     },
     "packages/msgraph-beta-sdk-employeeExperience": {
       "name": "@microsoft/msgraph-beta-sdk-employeeexperience",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2917,7 +2794,7 @@
     },
     "packages/msgraph-beta-sdk-external": {
       "name": "@microsoft/msgraph-beta-sdk-external",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2929,7 +2806,7 @@
     },
     "packages/msgraph-beta-sdk-filterOperators": {
       "name": "@microsoft/msgraph-beta-sdk-filteroperators",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2941,7 +2818,7 @@
     },
     "packages/msgraph-beta-sdk-financials": {
       "name": "@microsoft/msgraph-beta-sdk-financials",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2953,7 +2830,7 @@
     },
     "packages/msgraph-beta-sdk-functions": {
       "name": "@microsoft/msgraph-beta-sdk-functions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2965,7 +2842,7 @@
     },
     "packages/msgraph-beta-sdk-governanceResources": {
       "name": "@microsoft/msgraph-beta-sdk-governanceresources",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2977,7 +2854,7 @@
     },
     "packages/msgraph-beta-sdk-governanceRoleAssignmentRequests": {
       "name": "@microsoft/msgraph-beta-sdk-governanceroleassignmentrequests",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -2989,7 +2866,7 @@
     },
     "packages/msgraph-beta-sdk-governanceRoleAssignments": {
       "name": "@microsoft/msgraph-beta-sdk-governanceroleassignments",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3001,7 +2878,7 @@
     },
     "packages/msgraph-beta-sdk-governanceRoleDefinitions": {
       "name": "@microsoft/msgraph-beta-sdk-governanceroledefinitions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3013,7 +2890,7 @@
     },
     "packages/msgraph-beta-sdk-governanceRoleSettings": {
       "name": "@microsoft/msgraph-beta-sdk-governancerolesettings",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3025,7 +2902,7 @@
     },
     "packages/msgraph-beta-sdk-governanceSubjects": {
       "name": "@microsoft/msgraph-beta-sdk-governancesubjects",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3037,7 +2914,7 @@
     },
     "packages/msgraph-beta-sdk-groupLifecyclePolicies": {
       "name": "@microsoft/msgraph-beta-sdk-grouplifecyclepolicies",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3049,7 +2926,7 @@
     },
     "packages/msgraph-beta-sdk-groups": {
       "name": "@microsoft/msgraph-beta-sdk-groups",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3061,7 +2938,7 @@
     },
     "packages/msgraph-beta-sdk-identity": {
       "name": "@microsoft/msgraph-beta-sdk-identity",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3073,7 +2950,7 @@
     },
     "packages/msgraph-beta-sdk-identityGovernance": {
       "name": "@microsoft/msgraph-beta-sdk-identitygovernance",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3085,7 +2962,7 @@
     },
     "packages/msgraph-beta-sdk-identityProtection": {
       "name": "@microsoft/msgraph-beta-sdk-identityprotection",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3097,7 +2974,7 @@
     },
     "packages/msgraph-beta-sdk-identityProviders": {
       "name": "@microsoft/msgraph-beta-sdk-identityproviders",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3109,7 +2986,7 @@
     },
     "packages/msgraph-beta-sdk-informationProtection": {
       "name": "@microsoft/msgraph-beta-sdk-informationprotection",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3121,7 +2998,7 @@
     },
     "packages/msgraph-beta-sdk-invitations": {
       "name": "@microsoft/msgraph-beta-sdk-invitations",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3133,7 +3010,7 @@
     },
     "packages/msgraph-beta-sdk-messageEvents": {
       "name": "@microsoft/msgraph-beta-sdk-messageevents",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3145,7 +3022,7 @@
     },
     "packages/msgraph-beta-sdk-messageRecipients": {
       "name": "@microsoft/msgraph-beta-sdk-messagerecipients",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3157,7 +3034,7 @@
     },
     "packages/msgraph-beta-sdk-messageTraces": {
       "name": "@microsoft/msgraph-beta-sdk-messagetraces",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3169,7 +3046,7 @@
     },
     "packages/msgraph-beta-sdk-mobilityManagementPolicies": {
       "name": "@microsoft/msgraph-beta-sdk-mobilitymanagementpolicies",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3181,7 +3058,7 @@
     },
     "packages/msgraph-beta-sdk-monitoring": {
       "name": "@microsoft/msgraph-beta-sdk-monitoring",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3193,7 +3070,7 @@
     },
     "packages/msgraph-beta-sdk-networkAccess": {
       "name": "@microsoft/msgraph-beta-sdk-networkaccess",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3205,7 +3082,7 @@
     },
     "packages/msgraph-beta-sdk-oauth2PermissionGrants": {
       "name": "@microsoft/msgraph-beta-sdk-oauth2permissiongrants",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3217,7 +3094,7 @@
     },
     "packages/msgraph-beta-sdk-onPremisesPublishingProfiles": {
       "name": "@microsoft/msgraph-beta-sdk-onpremisespublishingprofiles",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3229,7 +3106,7 @@
     },
     "packages/msgraph-beta-sdk-organization": {
       "name": "@microsoft/msgraph-beta-sdk-organization",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3241,7 +3118,7 @@
     },
     "packages/msgraph-beta-sdk-payloadResponse": {
       "name": "@microsoft/msgraph-beta-sdk-payloadresponse",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3253,7 +3130,7 @@
     },
     "packages/msgraph-beta-sdk-permissionGrants": {
       "name": "@microsoft/msgraph-beta-sdk-permissiongrants",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3265,7 +3142,7 @@
     },
     "packages/msgraph-beta-sdk-places": {
       "name": "@microsoft/msgraph-beta-sdk-places",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3277,7 +3154,7 @@
     },
     "packages/msgraph-beta-sdk-planner": {
       "name": "@microsoft/msgraph-beta-sdk-planner",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3289,7 +3166,7 @@
     },
     "packages/msgraph-beta-sdk-policies": {
       "name": "@microsoft/msgraph-beta-sdk-policies",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3301,7 +3178,7 @@
     },
     "packages/msgraph-beta-sdk-print": {
       "name": "@microsoft/msgraph-beta-sdk-print",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3313,7 +3190,7 @@
     },
     "packages/msgraph-beta-sdk-privacy": {
       "name": "@microsoft/msgraph-beta-sdk-privacy",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3325,7 +3202,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedAccess": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedaccess",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3337,7 +3214,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedApproval": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedapproval",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3349,7 +3226,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedOperationEvents": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedoperationevents",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3361,7 +3238,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedRoleAssignmentRequests": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedroleassignmentrequests",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3373,7 +3250,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedRoleAssignments": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedroleassignments",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3385,7 +3262,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedRoles": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedroles",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3397,7 +3274,7 @@
     },
     "packages/msgraph-beta-sdk-privilegedSignupStatus": {
       "name": "@microsoft/msgraph-beta-sdk-privilegedsignupstatus",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3409,7 +3286,7 @@
     },
     "packages/msgraph-beta-sdk-programControls": {
       "name": "@microsoft/msgraph-beta-sdk-programcontrols",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3421,7 +3298,7 @@
     },
     "packages/msgraph-beta-sdk-programControlTypes": {
       "name": "@microsoft/msgraph-beta-sdk-programcontroltypes",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3433,7 +3310,7 @@
     },
     "packages/msgraph-beta-sdk-programs": {
       "name": "@microsoft/msgraph-beta-sdk-programs",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3445,7 +3322,7 @@
     },
     "packages/msgraph-beta-sdk-reports": {
       "name": "@microsoft/msgraph-beta-sdk-reports",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3457,7 +3334,7 @@
     },
     "packages/msgraph-beta-sdk-riskDetections": {
       "name": "@microsoft/msgraph-beta-sdk-riskdetections",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3469,7 +3346,7 @@
     },
     "packages/msgraph-beta-sdk-riskyUsers": {
       "name": "@microsoft/msgraph-beta-sdk-riskyusers",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3481,7 +3358,7 @@
     },
     "packages/msgraph-beta-sdk-roleManagement": {
       "name": "@microsoft/msgraph-beta-sdk-rolemanagement",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3493,7 +3370,7 @@
     },
     "packages/msgraph-beta-sdk-schemaExtensions": {
       "name": "@microsoft/msgraph-beta-sdk-schemaextensions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3505,7 +3382,7 @@
     },
     "packages/msgraph-beta-sdk-scopedRoleMemberships": {
       "name": "@microsoft/msgraph-beta-sdk-scopedrolememberships",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3517,7 +3394,7 @@
     },
     "packages/msgraph-beta-sdk-search": {
       "name": "@microsoft/msgraph-beta-sdk-search",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3529,7 +3406,7 @@
     },
     "packages/msgraph-beta-sdk-security": {
       "name": "@microsoft/msgraph-beta-sdk-security",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3541,7 +3418,7 @@
     },
     "packages/msgraph-beta-sdk-servicePrincipals": {
       "name": "@microsoft/msgraph-beta-sdk-serviceprincipals",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3553,7 +3430,7 @@
     },
     "packages/msgraph-beta-sdk-settings": {
       "name": "@microsoft/msgraph-beta-sdk-settings",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3565,7 +3442,7 @@
     },
     "packages/msgraph-beta-sdk-shares": {
       "name": "@microsoft/msgraph-beta-sdk-shares",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3577,7 +3454,7 @@
     },
     "packages/msgraph-beta-sdk-sites": {
       "name": "@microsoft/msgraph-beta-sdk-sites",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3589,7 +3466,7 @@
     },
     "packages/msgraph-beta-sdk-solutions": {
       "name": "@microsoft/msgraph-beta-sdk-solutions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3601,7 +3478,7 @@
     },
     "packages/msgraph-beta-sdk-subscribedSkus": {
       "name": "@microsoft/msgraph-beta-sdk-subscribedskus",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3613,7 +3490,7 @@
     },
     "packages/msgraph-beta-sdk-subscriptions": {
       "name": "@microsoft/msgraph-beta-sdk-subscriptions",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3625,7 +3502,7 @@
     },
     "packages/msgraph-beta-sdk-teams": {
       "name": "@microsoft/msgraph-beta-sdk-teams",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3637,7 +3514,7 @@
     },
     "packages/msgraph-beta-sdk-teamsTemplates": {
       "name": "@microsoft/msgraph-beta-sdk-teamstemplates",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3649,7 +3526,7 @@
     },
     "packages/msgraph-beta-sdk-teamTemplateDefinition": {
       "name": "@microsoft/msgraph-beta-sdk-teamtemplatedefinition",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3661,7 +3538,7 @@
     },
     "packages/msgraph-beta-sdk-teamwork": {
       "name": "@microsoft/msgraph-beta-sdk-teamwork",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3673,7 +3550,7 @@
     },
     "packages/msgraph-beta-sdk-tenantRelationships": {
       "name": "@microsoft/msgraph-beta-sdk-tenantrelationships",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3685,7 +3562,7 @@
     },
     "packages/msgraph-beta-sdk-termStore": {
       "name": "@microsoft/msgraph-beta-sdk-termstore",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3697,7 +3574,7 @@
     },
     "packages/msgraph-beta-sdk-tests": {
       "name": "@microsoft/msgraph-beta-sdk-tests",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -3718,7 +3595,7 @@
     },
     "packages/msgraph-beta-sdk-threatSubmission": {
       "name": "@microsoft/msgraph-beta-sdk-threatsubmission",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3730,7 +3607,7 @@
     },
     "packages/msgraph-beta-sdk-trustFramework": {
       "name": "@microsoft/msgraph-beta-sdk-trustframework",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",
@@ -3742,7 +3619,7 @@
     },
     "packages/msgraph-beta-sdk-users": {
       "name": "@microsoft/msgraph-beta-sdk-users",
-      "version": "1.0.0-preview.75",
+      "version": "1.0.0-preview.76",
       "license": "MIT",
       "dependencies": {
         "@microsoft/msgraph-beta-sdk": "^1.0.0-preview.38",

--- a/packages/msgraph-beta-sdk/package.json
+++ b/packages/msgraph-beta-sdk/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/microsoftgraph/msgraph-beta-sdk-typescript/issues"
   },
   "dependencies": {
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.100",
+    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
     "@microsoft/msgraph-sdk-core": "^1.0.0-preview.17",
     "tslib": "^2.6.2"
   },


### PR DESCRIPTION
## Summary

This PR updates @microsoft/kiota-http-fetchlibrary and other outdated npm dependencies to resolve a critical security vulnerability (GHSA-396q-4vc8-28x9).

## Issue

Fixes #491

## Security Vulnerability Details

**GHSA-396q-4vc8-28x9: Bearer token leak across origin in RedirectHandler**

The vulnerability affects @microsoft/kiota-http-fetchlibrary versions 1.0.0-preview.97 through 1.0.0-preview.101.

### Root Cause
The RedirectHandler's default scrubbing callback uses case-sensitive property deletion on a headers object that has already been lower-cased by the request adapter. This causes sensitive headers (Authorization, Cookie) to not be properly removed during cross-origin redirects.

### Impact
- Bearer tokens in Authorization headers are leaked to attacker-controlled hosts during HTTP redirects
- Affects all kiota-generated TypeScript SDKs using authentication providers
- Applies to the default middleware chain with no custom configuration required
- No user interaction needed to trigger the vulnerability

### Fix
Update @microsoft/kiota-http-fetchlibrary from 1.0.0-preview.100 to 1.0.0-preview.102

## Changes
- Updated @microsoft/kiota-http-fetchlibrary to 1.0.0-preview.102
- Updated all other outdated dependencies to their latest versions
- These changes ensure proper scrubbing of sensitive headers during cross-origin redirects

## References
- Advisory: https://github.com/microsoft/kiota-typescript/security/advisories/GHSA-396q-4vc8-28x9
- Related Issue: #491