### PR TITLE
chore(deps): consolidate open dependabot dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         # Single version should work for compilation testing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Generate GitHub App token
         id: app-token

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@types/node": "^26.1.0",
         "rimraf": "^6.0.1"
       }
     },
@@ -875,13 +876,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -1479,10 +1480,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2126,9 +2137,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3588,7 +3599,7 @@
       "devDependencies": {
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^25.8.0",
+        "@types/node": "^26.1.0",
         "chai": "^6.0.1",
         "mocha": "^11.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "npm run test -w @microsoft/msgraph-beta-sdk-tests"
   },
   "devDependencies": {
+    "@types/node": "^26.1.0",
     "rimraf": "^6.0.1"
   },
   "version": "1.0.0-preview.76"

--- a/packages/msgraph-beta-sdk-tests/package.json
+++ b/packages/msgraph-beta-sdk-tests/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^25.8.0",
+    "@types/node": "^26.1.0",
     "chai": "^6.0.1",
     "mocha": "^11.0.1"
   },


### PR DESCRIPTION
## Summary

| Package/Action | From | To | Source PR |
| --- | --- | --- | --- |
| @types/node (root package.json) | 25.9.1 | 26.1.0 | #505 |
| @types/node (packages/msgraph-beta-sdk-tests) | 25.9.4 | 26.1.0 | #506 |
| js-yaml | 4.1.1 | 4.3.0 | #501 |
| actions/checkout | v6 | v7 | #497 |

Regenerated the root `package-lock.json` with `npm install` so the workspace @types/node updates are in sync, including @types/node 26.1.0 and undici-types 8.3.0. The kiota-dependencies group #498 was intentionally excluded.

## Validation

- `npm ci`
- `npm run build`

Closes #506
Closes #505
Closes #501
Closes #497
