### PR TITLE
Route npm install through the CFS central package feed

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -53,6 +53,8 @@ extends:
           inputs:
             command: 'ci'
             verbose: true
+            customRegistry: 'useFeed'
+            customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
           displayName: 'Install npm dependencies with retry'
 
         - script: npm run build


### PR DESCRIPTION
Routes npm dependency installation through the authenticated `GraphDeveloperExperiences_Public` Azure Artifacts feed (network isolation / CFS compliance). Needs a pipeline run to validate.